### PR TITLE
A compatibility fix I needed for myself (Rails3/RSpec2.5.1/REE1.8.7)

### DIFF
--- a/lib/nulldb_rspec.rb
+++ b/lib/nulldb_rspec.rb
@@ -83,12 +83,12 @@ module NullDB::RSpec::NullifiedDatabase
   def self.nullify_contextually?(other)
     rspec_root = defined?(RSpec) ? RSpec : Spec
     if defined? rspec_root::Rails::RailsExampleGroup
-      other.ancestors.include?(rspec_root::Rails::RailsExampleGroup)
+      other.included_modules.include?(rspec_root::Rails::RailsExampleGroup)
     else
-      other.ancestors.include?(rspec_root::Rails::ModelExampleGroup) ||
-        other.ancestors.include?(rspec_root::Rails::ControllerExampleGroup) ||
-        other.ancestors.include?(rspec_root::Rails::ViewExampleGroup) ||
-        other.ancestors.include?(rspec_root::Rails::HelperExampleGroup)
+      other.included_modules.include?(rspec_root::Rails::ModelExampleGroup) ||
+        other.included_modules.include?(rspec_root::Rails::ControllerExampleGroup) ||
+        other.included_modules.include?(rspec_root::Rails::ViewExampleGroup) ||
+        other.included_modules.include?(rspec_root::Rails::HelperExampleGroup)
     end
   end
 


### PR DESCRIPTION
So, this change seems to solve my problems and make nullification work either globally or contextually, depending on where the include is placed. 
However, I can't figure out how to write a test for this - speccing something interacting with RSpec is a little too meta for me right now. And I didn't see any tests for this that I could work from, so I feel a bit stuck without deeper RSpec knowledge. Anyway - it feels like a pretty minor change that won't break anything, so I'm submitting it and I'd be willing to learn how to write those tests if needed. 
