### PR TITLE
Moving away from Rails and RSpec dependence

### DIFF
--- a/activerecord-nulldb-adapter.gemspec
+++ b/activerecord-nulldb-adapter.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Avdi Grimm", "Myron Marston"]
-  s.date = %q{2010-09-01}
+  s.date = %q{2011-09-12}
   s.description = %q{A database backend that translates database interactions into no-ops. Using NullDB enables you to test your model business logic - including after_save hooks - without ever touching a real database.}
   s.email = %q{myron.marston@gmail.com}
   s.extra_rdoc_files = [
@@ -18,12 +18,16 @@ Gem::Specification.new do |s|
   ]
   s.files = [
     ".gitignore",
+     "Gemfile",
+     "Gemfile.lock",
      "LICENSE",
      "README.rdoc",
      "Rakefile",
      "VERSION",
      "activerecord-nulldb-adapter.gemspec",
      "ginger_scenarios.rb",
+     "lib/nulldb.rb",
+     "lib/activerecord-nulldb-adapter.rb",
      "lib/active_record/connection_adapters/nulldb_adapter.rb",
      "lib/nulldb/arel_compiler.rb",
      "lib/nulldb_rspec.rb",
@@ -46,13 +50,8 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      if ENV['TEST_RAILS_3_1']
-        s.add_runtime_dependency(%q<activerecord>, [">= 3.1.0.rc4"])
-      else
-        s.add_runtime_dependency(%q<activerecord>, [">= 2.0.0", "< 3.1"])
-      end
+      s.add_runtime_dependency(%q<activerecord>, [">= 2.0.0", "< 3.1"])
       s.add_development_dependency(%q<rspec>, [">= 1.2.9"])
-      s.add_development_dependency(%q<rake>)
     else
       s.add_dependency(%q<activerecord>, [">= 2.0.0", "< 3.1"])
       s.add_dependency(%q<rspec>, [">= 1.2.9"])

--- a/lib/active_record/connection_adapters/nulldb_adapter.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter.rb
@@ -1,6 +1,7 @@
 require 'logger'
 require 'stringio'
 require 'singleton'
+require 'pathname'
 require 'active_record/connection_adapters/abstract_adapter'
 
 unless respond_to?(:tap)
@@ -159,7 +160,12 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter <
   def columns(table_name, name = nil)
     if @tables.size <= 1
       ActiveRecord::Migration.verbose = false
-      Kernel.load(File.join(Rails.root, @schema_path))
+      schema_path = if Pathname(@schema_path).absolute?
+                      @schema_path
+                    else
+                      File.join(Rails.root, @schema_path)
+                    end
+      Kernel.load(schema_path)
     end
 
     if table = @tables[table_name]

--- a/lib/activerecord-nulldb-adapter.rb
+++ b/lib/activerecord-nulldb-adapter.rb
@@ -1,0 +1,1 @@
+require 'nulldb'

--- a/lib/nulldb.rb
+++ b/lib/nulldb.rb
@@ -1,0 +1,17 @@
+module NullDB
+  def self.nullify(options={})
+    @prev_connection = ActiveRecord::Base.connection_pool.try(:spec)
+    ActiveRecord::Base.establish_connection(options.merge(:adapter => :nulldb))
+  end
+  
+  def self.restore
+    if @prev_connection
+      ActiveRecord::Base.establish_connection(@prev_connection)
+    end
+  end
+
+  def self.checkpoint
+    ActiveRecord::Base.connection.checkpoint!
+  end
+end
+


### PR DESCRIPTION
- No longer try to read Rails.root if the schema path is absolute.
- Define NullDB.nullify, NullDB.restore, and NullDB.checkpoint
