### PR TITLE
Fix 'primary_key' on primary-key-less tables

### DIFF
--- a/lib/active_record/connection_adapters/nulldb_adapter.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter.rb
@@ -238,7 +238,7 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter <
   end
 
   def primary_key(table_name)
-    columns(table_name).detect { |col| col.sql_type == :primary_key }.name
+    columns(table_name).detect { |col| col.sql_type == :primary_key }.try(:name)
   end
 
   protected

--- a/spec/nulldb_spec.rb
+++ b/spec/nulldb_spec.rb
@@ -76,6 +76,11 @@ describe "NullDB" do
         t.decimal :salary
       end
 
+      create_table(:employees_widgets, :id => false) do |t|
+        t.integer :employee_id
+        t.integer :widget_id
+      end
+
       add_fk_constraint "foo", "bar", "baz", "buz", "bungle"
       add_pk_constraint "foo", "bar", {}, "baz", "buz"
     end
@@ -106,6 +111,10 @@ describe "NullDB" do
 
   it "should return the appropriate primary key" do
     ActiveRecord::Base.connection.primary_key('employees').should == 'id'
+  end
+
+  it "should return a nil primary key on habtm" do
+    ActiveRecord::Base.connection.primary_key('employees_widgets').should be_nil
   end
 
   it "should return an empty array of columns for a table-less model" do


### PR DESCRIPTION
Currently, nulldb is erroring when it encounters a habtm relationship. It's erroring on the connection adapter's `primary_key`, since habtm dosen't have one. I think it's OK for `primary_key` to return nil, since this is the definition for the mysql adapter:

```
def primary_key(table)
  pk_and_sequence = pk_and_sequence_for(table)
  pk_and_sequence && pk_and_sequence.first
end
```

Note the last line can return nil if pk_and_sequence is nil, so I take this to mean AR is OK with primary_key returning nil.
