### PR TITLE
Pull Rails-oriented code out of main code body

### DIFF
--- a/lib/active_record/connection_adapters/nulldb_adapter.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter.rb
@@ -3,6 +3,7 @@ require 'stringio'
 require 'singleton'
 require 'pathname'
 require 'active_record/connection_adapters/abstract_adapter'
+require 'nulldb/core'
 
 unless respond_to?(:tap)
   class Object
@@ -22,6 +23,10 @@ unless respond_to?(:try)
         __send__(*a, &b)
       end
     end
+  end
+
+  class NilClass
+    def try(*args); nil; end
   end
 end
 
@@ -175,7 +180,7 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter <
       schema_path = if Pathname(@schema_path).absolute?
                       @schema_path
                     else
-                      File.join(Rails.root, @schema_path)
+                      File.join(NullDB.configuration.project_root, @schema_path)
                     end
       Kernel.load(schema_path)
     end

--- a/lib/nulldb.rb
+++ b/lib/nulldb.rb
@@ -1,17 +1,2 @@
-module NullDB
-  def self.nullify(options={})
-    @prev_connection = ActiveRecord::Base.connection_pool.try(:spec)
-    ActiveRecord::Base.establish_connection(options.merge(:adapter => :nulldb))
-  end
-  
-  def self.restore
-    if @prev_connection
-      ActiveRecord::Base.establish_connection(@prev_connection)
-    end
-  end
-
-  def self.checkpoint
-    ActiveRecord::Base.connection.checkpoint!
-  end
-end
-
+require 'nulldb/core'
+require 'nulldb/rails'

--- a/lib/nulldb/core.rb
+++ b/lib/nulldb/core.rb
@@ -1,0 +1,34 @@
+require 'active_record/connection_adapters/nulldb_adapter'
+
+module NullDB
+  class Configuration < Struct.new(:project_root); end
+
+  class << self
+    def configure
+      @configuration = Configuration.new.tap {|c| yield c}
+    end
+
+    def configuration
+      if @configuration.nil?
+        raise "NullDB not configured. Require a framework, ex 'nulldb/rails'"
+      end
+
+      @configuration
+    end
+
+    def nullify(options={})
+      @prev_connection = ActiveRecord::Base.connection_pool.try(:spec)
+      ActiveRecord::Base.establish_connection(options.merge(:adapter => :nulldb))
+    end
+
+    def restore
+      if @prev_connection
+        ActiveRecord::Base.establish_connection(@prev_connection)
+      end
+    end
+
+    def checkpoint
+      ActiveRecord::Base.connection.checkpoint!
+    end
+  end
+end

--- a/lib/nulldb/rails.rb
+++ b/lib/nulldb/rails.rb
@@ -1,0 +1,3 @@
+require 'nulldb/core'
+
+NullDB.configure {|ndb| ndb.project_root = Rails.root}

--- a/lib/nulldb_rspec.rb
+++ b/lib/nulldb_rspec.rb
@@ -82,14 +82,7 @@ module NullDB::RSpec::NullifiedDatabase
 
   def self.nullify_contextually?(other)
     rspec_root = defined?(RSpec) ? RSpec : Spec
-    if defined? rspec_root::Rails::RailsExampleGroup
-      other.included_modules.include?(rspec_root::Rails::RailsExampleGroup)
-    else
-      other.included_modules.include?(rspec_root::Rails::ModelExampleGroup) ||
-        other.included_modules.include?(rspec_root::Rails::ControllerExampleGroup) ||
-        other.included_modules.include?(rspec_root::Rails::ViewExampleGroup) ||
-        other.included_modules.include?(rspec_root::Rails::HelperExampleGroup)
-    end
+    other.is_a?(rspec_root::Core::ExampleGroup)
   end
 
   def self.nullify_database(receiver)

--- a/spec/nulldb_spec.rb
+++ b/spec/nulldb_spec.rb
@@ -24,11 +24,7 @@ end
 class TablelessModel < ActiveRecord::Base
 end
 
-module Rails
-  def self.root
-    'Rails.root'
-  end
-end
+NullDB.configure {|ndb| ndb.project_root = 'Rails.root'}
 
 describe "NullDB with no schema pre-loaded" do
   before :each do


### PR DESCRIPTION
so that testing the RSpec integration doesn't require a Rails
environment or monkey-patching.

I can't test the rspec integration w/o stubbing some rails code, so I thought I'd see what it would take to pull the rails-specific code into a separate file.

I like the implementation in this commit for the most part, except adding a configure block might be a bit premature. I could have done the same thing with a NullDB class method, but I think this communicates intent better.

Thoughts?

If this looks good, I can merge in some tests and a fix for #11, as well as think about replicating #4 with a test.
