### PR TITLE
1 more Rails 3.1 change besides those in dde42ffb

### DIFF
--- a/lib/active_record/connection_adapters/nulldb_adapter.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter.rb
@@ -224,7 +224,7 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter <
   end
   alias :create :insert
 
-  def update(statement, name=nil)
+  def update(statement, name=nil, binds = [])
     with_entry_point(:update) do
       super(statement, name)
     end


### PR DESCRIPTION
see gems/activerecord-3.1.2/lib/active_record/relation.rb:233

I'm not sure under what circumstances this is hit (I ran into this in a
has_one association: my_model.my_other_model = MyOtherModel.new), or how to write a
spec for it.
