### PR TITLE
Fix case where Rails engine testing may result in a not yet connected da...

### DIFF
--- a/lib/nulldb/core.rb
+++ b/lib/nulldb/core.rb
@@ -17,7 +17,10 @@ module NullDB
     end
 
     def nullify(options={})
-      @prev_connection = ActiveRecord::Base.connection_pool.try(:spec)
+      begin
+        @prev_connection = ActiveRecord::Base.connection_pool.try(:spec)
+      rescue ActiveRecord::ConnectionNotEstablished
+      end
       ActiveRecord::Base.establish_connection(options.merge(:adapter => :nulldb))
     end
 

--- a/spec/nulldb_spec.rb
+++ b/spec/nulldb_spec.rb
@@ -228,6 +228,11 @@ describe "NullDB" do
     col.should_not be_nil
     col.type.should == col_type
   end
+
+  it 'should handle ActiveRecord::ConnectionNotEstablished' do
+    ActiveRecord::Base.should_receive(:connection_pool).and_raise(ActiveRecord::ConnectionNotEstablished)
+    lambda { NullDB.nullify }.should_not raise_error(ActiveRecord::ConnectionNotEstablished)
+  end
 end
 
 # need a fallback db for contextual nullification


### PR DESCRIPTION
...tabase.

In the project I was working on, I was encountering a point where the
ActiveRecord::Base.connection_pool had not yet been connected. This raised an
exception. This patch catches the current exception that is thrown.

I'm not entirely satisified with the exception handling, as it relates to the
inner working of ActiveRecord::Base; However, NullDB is meant to be an
ActiveRecord adaptor, so this is perhaps germain to the test suite.
