### PR TITLE
Fix case where Rails engine testing may result in a not yet connected da...

### DIFF
--- a/lib/nulldb/core.rb
+++ b/lib/nulldb/core.rb
@@ -17,7 +17,10 @@ module NullDB
     end
 
     def nullify(options={})
-      @prev_connection = ActiveRecord::Base.connection_pool.try(:spec)
+      begin
+        @prev_connection = ActiveRecord::Base.connection_pool.try(:spec)
+      rescue ActiveRecord::ConnectionNotEstablished
+      end
       ActiveRecord::Base.establish_connection(options.merge(:adapter => :nulldb))
     end
 

--- a/spec/nulldb_spec.rb
+++ b/spec/nulldb_spec.rb
@@ -232,6 +232,7 @@ describe "NullDB" do
     col.should_not be_nil
     col.type.should == col_type
   end
+
   
   it "should support adding indexes" do
     Employee.connection.indexes('employees').size.should == 2
@@ -249,6 +250,11 @@ describe "NullDB" do
   
   it "should support custom index names" do
     Employee.connection.indexes('employees_widgets').first.name.should == 'my_index'
+  end
+
+  it 'should handle ActiveRecord::ConnectionNotEstablished' do
+    ActiveRecord::Base.should_receive(:connection_pool).and_raise(ActiveRecord::ConnectionNotEstablished)
+    lambda { NullDB.nullify }.should_not raise_error(ActiveRecord::ConnectionNotEstablished)
   end
 end
 


### PR DESCRIPTION
...tabase.

In the project I was working on, I was encountering a point where the
ActiveRecord::Base.connection_pool had not yet been connected. This raised an
exception. This patch catches the current exception that is thrown.

I'm not entirely satisified with the exception handling, as it relates to the
inner working of ActiveRecord::Base; However, NullDB is meant to be an
ActiveRecord adaptor, so this is perhaps germain to the test suite.
