### PR TITLE
Stringify IndexDefinition column names

### DIFF
--- a/lib/active_record/connection_adapters/nulldb_adapter.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter.rb
@@ -166,6 +166,7 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter <
   end
 
   def add_index(table_name, column_names, options = {})
+    column_names = Array.wrap(column_names).map(&:to_s)
     index_name, index_type, ignore = add_index_options(table_name, column_names, options)
     @indexes[table_name] << IndexDefinition.new(table_name, index_name, (index_type == 'UNIQUE'), column_names, [], [])
   end

--- a/spec/nulldb_spec.rb
+++ b/spec/nulldb_spec.rb
@@ -75,7 +75,7 @@ describe "NullDB" do
         t.integer :widget_id
       end
 
-      add_index "employees", ["name"], :name => "index_employees_on_name"
+      add_index "employees", :name, :name => "index_employees_on_name"
       add_index "employees", ["employee_number"], :name => "index_employees_on_employee_number", :unique => true
       add_index "employees_widgets", ["employee_id", "widget_id"], :name => "my_index"
       


### PR DESCRIPTION
Can't run db:migrate because schema_migrations indexes the `:version` column by passing the name of that column as a symbol. This change ensure that the column_names argument to add_index gets stringified before constructing IndexDefinitions. Since other adapters get column names from querying the database, they don't have to worry about rogue symbols.

```
* Execute db:migrate
rake aborted!
undefined method `+' for :version:Symbol
/Users/riley/.rbenv/versions/1.9.3-p327/gemsets/fokus/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract/schema_statements.rb:554:in `block in quoted_columns_for_index'
/Users/riley/.rbenv/versions/1.9.3-p327/gemsets/fokus/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract/schema_statements.rb:554:in `map'
/Users/riley/.rbenv/versions/1.9.3-p327/gemsets/fokus/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract/schema_statements.rb:554:in `quoted_columns_for_index'
/Users/riley/.rbenv/versions/1.9.3-p327/gemsets/fokus/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract/schema_statements.rb:578:in `add_index_options'
/Users/riley/Projects/gems/nulldb/lib/active_record/connection_adapters/nulldb_adapter.rb:169:in `add_index'
```
