### PR TITLE
NullObject should respond to #to_a and return empty Array

### DIFF
--- a/lib/active_record/connection_adapters/nulldb_adapter.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter.rb
@@ -92,6 +92,10 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter <
     def method_missing(*args, &block)
       nil
     end
+
+    def to_a
+      []
+    end
   end
 
   class EmptyResult < Array

--- a/spec/nulldb_spec.rb
+++ b/spec/nulldb_spec.rb
@@ -232,6 +232,12 @@ describe "NullDB" do
     Employee.connection.execute("blah").finish
   end
 
+  it "should #to_a return empty array on the result of #execute" do
+    result = Employee.connection.execute("blah")
+    result.to_a.should be_a Array
+    result.to_a.should be_empty
+  end
+
   def should_have_column(klass, col_name, col_type)
     col = klass.columns_hash[col_name.to_s]
     col.should_not be_nil


### PR DESCRIPTION
because you code may containt code like this:
ActiveRecord::Base.connection.execute(query).to_a.flatten.first
