### PR TITLE
Add explicit dependencies on activerecord:migration

### DIFF
--- a/lib/active_record/connection_adapters/nulldb_adapter.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter.rb
@@ -3,6 +3,8 @@ require 'stringio'
 require 'singleton'
 require 'pathname'
 require 'active_record/connection_adapters/abstract_adapter'
+require 'active_record/errors'
+require 'active_record/migration'
 require 'nulldb/core'
 
 unless respond_to?(:tap)


### PR DESCRIPTION
This patch enables `require 'nulldb'` outside rails

ActiveRecord::Migration is required for L45
ActiveRecord::ActiveRecordError is required for ActiveRecord::Migration
