### PR TITLE
require active support dependencies

### DIFF
--- a/lib/nulldb/core.rb
+++ b/lib/nulldb/core.rb
@@ -1,3 +1,5 @@
+require 'active_support'
+require 'active_support/deprecation'
 require 'active_record/connection_adapters/nulldb_adapter'
 
 module NullDB


### PR DESCRIPTION
I was having issues with active support dependencies when using nulldb outside of a Rails app. Here is a PR for the fix I found and commented about in issue #38.
