### PR TITLE
Support 'enable_extension" in schema definition

### DIFF
--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -112,6 +112,10 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
     # NOOP
   end
 
+  def enable_extension(*)
+    # NOOP
+  end
+
   # Retrieve the table names defined by the schema
   def tables
     @tables.keys.map(&:to_s)

--- a/spec/nulldb_spec.rb
+++ b/spec/nulldb_spec.rb
@@ -307,3 +307,19 @@ describe NullDB::RSpec::NullifiedDatabase do
     end
   end
 end
+
+
+describe 'adapter-specific extensions' do
+  before(:all) do
+    ActiveRecord::Base.establish_connection :adapter => :nulldb
+    ActiveRecord::Migration.verbose = false
+  end
+
+  it "supports 'enable_extension' in the schema definition" do
+    expect{
+      ActiveRecord::Schema.define do
+        enable_extension "plpgsql"
+      end
+    }.to_not raise_error
+  end
+end


### PR DESCRIPTION
Adds support for 'enable_extension' to the NullDB ActiveRecord::Migration stub.

There is, as of yet, no feature in nulldb to generically load implementation specific stubs. I know this is PostgreSQL-specific, but it was holding-up my tests. 
I would request this to be merged and marked for a refactor into something more generic later on. (#40)