### PR TITLE
add MIT license metadata to gemspec

### DIFF
--- a/activerecord-nulldb-adapter.gemspec
+++ b/activerecord-nulldb-adapter.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.date = %q{2011-09-12}
   s.description = %q{A database backend that translates database interactions into no-ops. Using NullDB enables you to test your model business logic - including after_save hooks - without ever touching a real database.}
   s.email = %q{myron.marston@gmail.com}
+  s.license = %q{MIT}
   s.extra_rdoc_files = [
     "LICENSE",
      "README.rdoc"


### PR DESCRIPTION
This pull request allows RubyGems.org and other tools (such as gem2rpm) to report a license for your gem.
