### PR TITLE
use HTTPS for URL in gemspec

### DIFF
--- a/activerecord-nulldb-adapter.gemspec
+++ b/activerecord-nulldb-adapter.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
      "spec/nulldb_spec.rb",
      "spec/spec.opts"
   ]
-  s.homepage = %q{http://github.com/nulldb/nulldb}
+  s.homepage = %q{https://github.com/nulldb/nulldb}
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{nulldb}


### PR DESCRIPTION
This pull request updates the nulldb gemspec metadata to use an encrypted HTTPS URL for the gem's homepage.
