### PR TITLE
Fixed column type error when loading schema from db/schema.rb on Rails 4.2

### DIFF
--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -134,6 +134,7 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
         ActiveRecord::ConnectionAdapters::NullDBAdapter::Column.new(
           col_def.name.to_s,
           col_def.default,
+          lookup_cast_type(col_def.type),
           col_def.type,
           col_def.null
         )


### PR DESCRIPTION
- Error looks like this: "NoMethodError: undefined method `type_cast_from_database' for :primary_key:Symbol"
- ActiveRecord::ConnectionAdapters::Column#initialize now takes "name, default, cast_type, sql_type, null" respectively
- In this commit, I set "cast_type" as the third param