### PR TITLE
Fix problems with AR 4.2

### DIFF
--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -134,6 +134,7 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
         ActiveRecord::ConnectionAdapters::NullDBAdapter::Column.new(
           col_def.name.to_s,
           col_def.default,
+          lookup_cast_type(col_def.type),
           col_def.type,
           col_def.null
         )

--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -129,15 +129,26 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
       Kernel.load(schema_path)
     end
 
+    takes_cast_type = defined?(ActiveRecord::Type::Value)
+
     if table = @tables[table_name]
       table.columns.map do |col_def|
-        ActiveRecord::ConnectionAdapters::NullDBAdapter::Column.new(
-          col_def.name.to_s,
-          col_def.default,
-          lookup_cast_type(col_def.type),
-          col_def.type,
-          col_def.null
-        )
+        if takes_cast_type
+          ActiveRecord::ConnectionAdapters::NullDBAdapter::Column.new(
+            col_def.name.to_s,
+            col_def.default,
+            lookup_cast_type(col_def.type),
+            col_def.type,
+            col_def.null
+          )
+        else
+          ActiveRecord::ConnectionAdapters::NullDBAdapter::Column.new(
+            col_def.name.to_s,
+            col_def.default,
+            col_def.type,
+            col_def.null
+          )
+        end
       end
     else
       []

--- a/lib/active_record/connection_adapters/nulldb_adapter/empty_result.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/empty_result.rb
@@ -13,6 +13,14 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter
     def columns
       @columns ||= []
     end
+
+    def > other
+      self.length > other
+    end
+
+    def < other
+      self.length < other
+    end
   end
 
 end

--- a/lib/active_record/connection_adapters/nulldb_adapter/empty_result.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/empty_result.rb
@@ -13,14 +13,5 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter
     def columns
       @columns ||= []
     end
-
-    def > other
-      self.length > other
-    end
-
-    def < other
-      self.length < other
-    end
   end
-
 end

--- a/spec/nulldb_spec.rb
+++ b/spec/nulldb_spec.rb
@@ -249,7 +249,7 @@ describe "NullDB" do
 
   def should_have_column(klass, col_name, col_type)
     col = klass.columns_hash[col_name.to_s]
-    expect(col.type).to eq col_type
+    expect(col.sql_type).to eq col_type
   end
 
 


### PR DESCRIPTION
This has @joongimin's fix, and now should work (as far as I've tested) with old and new versions of ActiveRecord. Also fixes a failing spec (which I believe is unrelated) that calls `#type` instead of `#sql_type`.