### PR TITLE
core: override active? to return true

### DIFF
--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -213,6 +213,10 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
     columns(table_name).detect { |col| col.sql_type == :primary_key }.try(:name)
   end
 
+  def active?
+    true
+  end
+
   protected
 
   def select(statement, name = nil, binds = [])


### PR DESCRIPTION
We use a check for whether the connection is `active?`, and in this case since we're mocking it it's safe to go with `true`. `AbstractAdapter` just has an empty method, which means it'll return `nil` by default.