### PR TITLE
Add support for `#cast_values` to `EmptyResult`

### DIFF
--- a/lib/active_record/connection_adapters/nulldb_adapter/empty_result.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/empty_result.rb
@@ -13,6 +13,10 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter
     def columns
       @columns ||= []
     end
+
+    def cast_values(type_overrides = nil)
+      rows
+    end
   end
 
 end

--- a/spec/nulldb_spec.rb
+++ b/spec/nulldb_spec.rb
@@ -323,3 +323,11 @@ describe 'adapter-specific extensions' do
     }.to_not raise_error
   end
 end
+
+describe ActiveRecord::ConnectionAdapters::NullDBAdapter::EmptyResult do
+  it "should return an empty array from #cast_values" do
+    result = described_class.new
+    expect( result.cast_values ).to be_a Array
+    expect( result.cast_values ).to be_empty
+  end
+end


### PR DESCRIPTION
Rails 4.2 added `ActiveRecord::Result#cast_values`, which does not exist in EmptyResult when using nulldb. Now calls to pluck on any relation object will raise a no method error.

This change adds `#cast_values` to EmptyResult, so the aforementioned pluck method returns an empty array when called. Older versions of active record are unaffected.