### PR TITLE
Add development dependency on rdoc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :development, :test do
   gem 'spec'
   gem 'rspec', '>= 1.2.9'
   gem 'rake'
+  gem 'rdoc'
 end
 
 group :development do

--- a/activerecord-nulldb-adapter.gemspec
+++ b/activerecord-nulldb-adapter.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'activerecord', '>= 2.0.0'
   s.add_development_dependency 'spec'
+  s.add_development_dependency 'rdoc'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'appraisal'


### PR DESCRIPTION
When I tried to run "bundle exec rake spec" I got an error because
Rakefile requires a file from rdoc.
