### PR TITLE
Rails master is pointing to arel 9 (only in github)

### DIFF
--- a/gemfiles/activerecord_master.gemfile
+++ b/gemfiles/activerecord_master.gemfile
@@ -6,6 +6,8 @@ git 'https://github.com/rails/rails.git' do
   gem 'activerecord'
 end
 
+gem 'arel', github: 'rails/arel', branch: 'master'
+
 group :development, :test do
   gem "spec"
   gem "rspec", ">= 1.2.9"


### PR DESCRIPTION
Rails master (which we test daily against) is pointing to a version of arel which is not released on rubygems. So this points our master gemfile to that repository to pass the tests and ensure we remain rails master (5.2) compatible.