### PR TITLE
Do not monkey patch AR Schema.define

### DIFF
--- a/lib/nulldb/extensions.rb
+++ b/lib/nulldb/extensions.rb
@@ -31,12 +31,3 @@ class ActiveRecord::Base
 end
 
 
-module ActiveRecord
-  # Just make sure you have the latest version of your schema
-  superclass = ActiveRecord::VERSION::MAJOR >= 5 ? Migration.public_send(:[], "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}".to_f) : Migration
-  class Schema < superclass
-    def self.define(info={}, &block)
-      new.define(info, &block)
-    end
-  end
-end

--- a/lib/nulldb/extensions.rb
+++ b/lib/nulldb/extensions.rb
@@ -36,7 +36,7 @@ module ActiveRecord
   superclass = ActiveRecord::VERSION::MAJOR >= 5 ? Migration.public_send(:[], "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}".to_f) : Migration
   class Schema < superclass
     def self.define(info={}, &block)
-      instance_eval(&block)
+      new.define(info, &block)
     end
   end
 end


### PR DESCRIPTION
I am not sure if the current code is intentional or possibly a bug. Currently our only need for nulldb is to run rake assets:precompile for production. See commit message. It may not seem apparent why this is needed but in our case we required nulldb in a rake task. Because of that and because nulldb monkey patches AR Schema.define we noticed that `rake db:schema:load` (with database.yml not using nulldb adapter) was not initializing the schema_migrations table. 