### PR TITLE
Fix broken count

### DIFF
--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -33,6 +33,8 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
       ActiveRecord::ConnectionAdapters::NullDBAdapter.const_set('TableDefinition',
         self.class.const_get(config[:table_definition_class_name]))
     end
+
+    register_types unless NullDB::LEGACY_ACTIVERECORD
   end
 
   # A log of every statement that has been "executed" by this connection adapter
@@ -331,4 +333,18 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
     [nil, @logger]
   end
 
+  # 4.2 introduced ActiveRecord::Type
+  # https://github.com/rails/rails/tree/4-2-stable/activerecord/lib/active_record
+  def register_types
+    if ActiveRecord::VERSION::MAJOR < 5
+      type_map.register_type(:primary_key, ActiveRecord::Type::Integer.new)
+    else
+      require 'active_model/type'
+      ActiveModel::Type.register(
+        :primary_key,
+        ActiveModel::Type::Integer,
+        adapter: 'NullDB'
+      )
+    end
+  end
 end

--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -229,7 +229,7 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
 
   def select(statement, name = nil, binds = [])
     EmptyResult.new.tap do |r|
-      r.columns = columns_for(name)
+      r.bind_column_meta(columns_for(name))
       self.execution_log << Statement.new(entry_point, statement)
     end
   end
@@ -237,10 +237,9 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
   private
 
   def columns_for(table_name)
-    table_def = @tables[table_name]
-    return {} unless table_def
-    names = table_def.columns.map(&:name)
-    Hash[names.zip(table_def.columns)]
+    table_meta = @tables[table_name]
+    return [] unless table_meta
+    table_meta.columns
   end
 
   def next_unique_id

--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -34,7 +34,8 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
         self.class.const_get(config[:table_definition_class_name]))
     end
 
-    register_types unless NullDB::LEGACY_ACTIVERECORD
+    register_types unless NullDB::LEGACY_ACTIVERECORD || \
+                          ActiveRecord::VERSION::MAJOR < 4
   end
 
   # A log of every statement that has been "executed" by this connection adapter
@@ -338,12 +339,13 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
   def register_types
     if ActiveRecord::VERSION::MAJOR < 5
       type_map.register_type(:primary_key, ActiveRecord::Type::Integer.new)
-    else
+    else      
       require 'active_model/type'
-      ActiveModel::Type.register(
+      ActiveRecord::Type.register(
         :primary_key,
         ActiveModel::Type::Integer,
-        adapter: 'NullDB'
+        adapter: adapter_name,
+        override: true
       )
     end
   end

--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -238,7 +238,9 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
 
   def columns_for(table_name)
     table_def = @tables[table_name]
-    table_def ? table_def.columns : []
+    return {} unless table_def
+    names = table_def.columns.map(&:name)
+    Hash[names.zip(table_def.columns)]
   end
 
   def next_unique_id

--- a/lib/active_record/connection_adapters/nulldb_adapter/empty_result.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/empty_result.rb
@@ -2,12 +2,9 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter
 
   class EmptyResult < Array
     attr_writer :columns
+    
     def rows
       []
-    end
-
-    def column_types
-      columns.map{|col| col.type}
     end
 
     def columns
@@ -21,6 +18,8 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter
     def >(num)
       rows.size > num
     end
+
+    alias_method :column_types, :columns
   end
 
 end

--- a/lib/active_record/connection_adapters/nulldb_adapter/empty_result.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/empty_result.rb
@@ -7,10 +7,10 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter
       @columns = columns
       return if columns.empty?
 
-      @column_types = begin
-        names = columns.map(&:name)
-        Hash[names.zip(table_def.columns)]
-      end
+      @column_types = columns.reduce({}) do |ctypes, col|
+        ctypes[col.name] = ActiveRecord::Type.lookup(col.type)
+        ctypes
+      end      
     end
 
     def columns

--- a/lib/active_record/connection_adapters/nulldb_adapter/empty_result.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/empty_result.rb
@@ -1,25 +1,38 @@
 class ActiveRecord::ConnectionAdapters::NullDBAdapter
 
   class EmptyResult < Array
-    attr_writer :columns
+    attr_reader :column_types
     
-    def rows
-      []
+    def bind_column_meta(columns)
+      @columns = columns
+      return if columns.empty?
+
+      @column_types = begin
+        names = columns.map(&:name)
+        Hash[names.zip(table_def.columns)]
+      end
     end
 
     def columns
       @columns ||= []
     end
 
+    def column_types
+      @column_types ||= {}
+    end
+
     def cast_values(type_overrides = nil)
       rows
+    end
+
+    def rows
+      []
     end
 
     def >(num)
       rows.size > num
     end
 
-    alias_method :column_types, :columns
   end
 
 end

--- a/lib/nulldb/core.rb
+++ b/lib/nulldb/core.rb
@@ -4,7 +4,7 @@ require 'active_record/connection_adapters/nulldb_adapter'
 
 module NullDB
   LEGACY_ACTIVERECORD = 
-    (ActiveRecord::VERSION::MAJOR < 5) && (ActiveRecord::VERSION::MINOR < 2)
+    Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('4.2.0')
 
   class Configuration < Struct.new(:project_root); end
 

--- a/lib/nulldb/core.rb
+++ b/lib/nulldb/core.rb
@@ -3,6 +3,9 @@ require 'active_support/deprecation'
 require 'active_record/connection_adapters/nulldb_adapter'
 
 module NullDB
+  LEGACY_ACTIVERECORD = 
+    (ActiveRecord::VERSION::MAJOR < 5) && (ActiveRecord::VERSION::MINOR < 2)
+
   class Configuration < Struct.new(:project_root); end
 
   class << self

--- a/lib/nulldb/extensions.rb
+++ b/lib/nulldb/extensions.rb
@@ -30,4 +30,4 @@ class ActiveRecord::Base
   end
 end
 
-
+ActiveRecord::Type.register(:primary_key, ActiveModel::Type::Integer, adapter: 'NullDB')

--- a/lib/nulldb/extensions.rb
+++ b/lib/nulldb/extensions.rb
@@ -29,5 +29,3 @@ class ActiveRecord::Base
     ActiveRecord::ConnectionAdapters::NullDBAdapter.new(config)
   end
 end
-
-ActiveRecord::Type.register(:primary_key, ActiveModel::Type::Integer, adapter: 'NullDB')

--- a/spec/nulldb_spec.rb
+++ b/spec/nulldb_spec.rb
@@ -339,7 +339,7 @@ describe 'adapter-specific extensions' do
     }.to_not raise_error
   end
 
-  if !NullDB::LEGACY_ACTIVERECORD
+  if ActiveRecord::VERSION::MAJOR > 4
     it 'registers a primary_key type' do
       expect(ActiveRecord::Type.lookup(:primary_key, adapter: 'NullDB'))
         .to be_a(ActiveModel::Type::Integer)

--- a/spec/nulldb_spec.rb
+++ b/spec/nulldb_spec.rb
@@ -339,9 +339,11 @@ describe 'adapter-specific extensions' do
     }.to_not raise_error
   end
 
-  it 'registers a primary_key type' do
-    expect(ActiveRecord::Type.lookup(:primary_key, adapter: 'NullDB'))
-      .to be_a(ActiveModel::Type::Integer)
+  if !NullDB::LEGACY_ACTIVERECORD
+    it 'registers a primary_key type' do
+      expect(ActiveRecord::Type.lookup(:primary_key, adapter: 'NullDB'))
+        .to be_a(ActiveModel::Type::Integer)
+    end
   end
 end
 

--- a/spec/nulldb_spec.rb
+++ b/spec/nulldb_spec.rb
@@ -338,6 +338,11 @@ describe 'adapter-specific extensions' do
       end
     }.to_not raise_error
   end
+
+  it 'registers a primary_key type' do
+    expect(ActiveRecord::Type.lookup(:primary_key, adapter: 'NullDB'))
+      .to be_a(ActiveModel::Type::Integer)
+  end
 end
 
 describe ActiveRecord::ConnectionAdapters::NullDBAdapter::EmptyResult do

--- a/spec/nulldb_spec.rb
+++ b/spec/nulldb_spec.rb
@@ -287,6 +287,10 @@ describe "NullDB" do
     expect( ActiveRecord::Base ).to receive(:connection_pool).and_raise(ActiveRecord::ConnectionNotEstablished)
     expect { NullDB.nullify }.to_not raise_error
   end
+
+  it 'should handle count queries' do 
+    expect(Employee.count).to eql(0)
+  end
 end
 
 # need a fallback db for contextual nullification


### PR DESCRIPTION
Resolves #49.

It appears that the ActiveRecord API has changed or maybe was interpreted incorrectly (?) causing this error. [I went on a small adventure](https://github.com/davidcelis/api-pagination/pull/95#issuecomment-397853842) trying to figure this one out and came to the conclusion that all of the other piping is fine and that a small tweak to the API of the nulldb `EmptyResult` object gives us a solution.

ActiveRecord uses the type metadata in this context, in `active_record/relations/calculations.rb` inside `#execute_simple_calculation`: 

```ruby
type   = result.column_types.fetch(column_alias) do
  type_for(column_name)
end
```

Well, it looks like we need to see what the `Result` API should implement. [What better place than the spec?](https://github.com/rails/rails/blob/15ef55efb591e5379486ccf53dd3e13f416564f6/activerecord/test/cases/result_test.rb)

```
    test "cast_values uses identity type for unknown types" do
      values = [["1.1", "2.2"], ["3.3", "4.4"]]
      columns = ["col1", "col2"]
      types = { "col1" => Type::Integer.new }
      result = Result.new(columns, values, types)

      assert_equal [[1, "2.2"], [3, "4.4"]], result.cast_values
    end
```

Cool. We need a Hash of column names to reified `ActiveRecord::Type` objects! Problem solved. I implemented this interface, but there was another issue:

```ruby
[1] pry(#<ActiveRecord::ConnectionAdapters::NullDBAdapter>)> ActiveRecord::Type.lookup(:primary_key)                                                                                       
ArgumentError: Unknown type :primary_key
from /home/mach/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/activemodel-5.2.0/lib/active_model/type/registry.rb:22:in `lookup'                                                          
```

We also have to register a `:primary_key` type with the `ActiveRecord::Type` registry, as this is a fairly common configuration that is exposed via `schema.rb`, so this functionality was also added to the project. 

I added a spec to check that `count` works, which previously did not exist and would fail without these changes as below: 

```
Failures:                                                                                                                                                                                   
                                                                                                                                                                                            
  1) NullDB should handle count queries                                                                                                                                                     
     Failure/Error: expect(Employee.count).to eql(0)                                                                                                                                        
                                                                                                                                                                                            
     TypeError:                                                                                                                                                                             
       no implicit conversion of String into Integer                                                                                                                                        
     # ./spec/nulldb_spec.rb:292:in `block (2 levels) in <top (required)>'                                                                                                                  
                                                                                                                                                                                            
Finished in 0.05611 seconds (files took 0.45248 seconds to load)                                                                                                                            
38 examples, 1 failure                                                                                                                                                                      
                                                                                                                                                                                            
Failed examples:                                                                                                                                                                            
                                                                                                                                                                                            
rspec ./spec/nulldb_spec.rb:291 # NullDB should handle count queries

Coverage report generated for RSpec to /home/mach/Workspace/nulldb/coverage. 250 / 311 LOC (80.39%) covered.                                                                               
```

There is also a spec around the type registry change. I hope that this solves a lot of workarounds!


