### PR TITLE
Prevent ActiveRecord::Tasks::DatabaseNotSupported

### DIFF
--- a/lib/active_record/connection_adapters/nulldb_adapter.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter.rb
@@ -19,3 +19,4 @@ require 'active_record/connection_adapters/nulldb_adapter/index_definition'
 require 'active_record/connection_adapters/nulldb_adapter/null_object'
 require 'active_record/connection_adapters/nulldb_adapter/table_definition'
 
+require 'active_record/tasks/nulldb_database_tasks'

--- a/lib/active_record/connection_adapters/nulldb_adapter.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter.rb
@@ -19,4 +19,4 @@ require 'active_record/connection_adapters/nulldb_adapter/index_definition'
 require 'active_record/connection_adapters/nulldb_adapter/null_object'
 require 'active_record/connection_adapters/nulldb_adapter/table_definition'
 
-require 'active_record/tasks/nulldb_database_tasks'
+require 'active_record/tasks/nulldb_database_tasks' if defined?(ActiveRecord::Tasks)

--- a/lib/active_record/tasks/nulldb_database_tasks.rb
+++ b/lib/active_record/tasks/nulldb_database_tasks.rb
@@ -1,0 +1,29 @@
+class ActiveRecord::Tasks::NullDBDatabaseTasks
+  def initialize(configuration)
+    @configuration = configuration
+  end
+
+  def create(master_established = false)
+    # NO-OP
+  end
+
+  def drop
+    # NO-OP
+  end
+
+  def purge
+    # NO-OP
+  end
+
+  def structure_dump(filename, extra_flags)
+    # NO-OP
+  end
+
+  def structure_load(filename, extra_flags)
+    # NO-OP
+  end
+
+  def clear_active_connections!
+    # NO-OP
+  end
+end

--- a/lib/nulldb/rails.rb
+++ b/lib/nulldb/rails.rb
@@ -3,4 +3,4 @@ require 'nulldb/core'
 # Need to defer calling Rails.root because when bundler loads, Rails.root is nil
 NullDB.configure {|ndb| def ndb.project_root;Rails.root;end}
 
-ActiveRecord::Tasks::DatabaseTasks.register_task(/nulldb/, 'ActiveRecord::Tasks::NullDBDatabaseTasks') if defined?(ActiveRecord::Tasks)
+ActiveRecord::Tasks::DatabaseTasks.register_task(/nulldb/, ActiveRecord::Tasks::NullDBDatabaseTasks) if defined?(ActiveRecord::Tasks)

--- a/lib/nulldb/rails.rb
+++ b/lib/nulldb/rails.rb
@@ -2,3 +2,5 @@ require 'nulldb/core'
 
 # Need to defer calling Rails.root because when bundler loads, Rails.root is nil
 NullDB.configure {|ndb| def ndb.project_root;Rails.root;end}
+
+ActiveRecord::Tasks::DatabaseTasks.register_task(/nulldb/, 'ActiveRecord::Tasks::NullDBDatabaseTasks')

--- a/lib/nulldb/rails.rb
+++ b/lib/nulldb/rails.rb
@@ -3,4 +3,4 @@ require 'nulldb/core'
 # Need to defer calling Rails.root because when bundler loads, Rails.root is nil
 NullDB.configure {|ndb| def ndb.project_root;Rails.root;end}
 
-ActiveRecord::Tasks::DatabaseTasks.register_task(/nulldb/, 'ActiveRecord::Tasks::NullDBDatabaseTasks')
+ActiveRecord::Tasks::DatabaseTasks.register_task(/nulldb/, 'ActiveRecord::Tasks::NullDBDatabaseTasks') if defined?(ActiveRecord::Tasks)


### PR DESCRIPTION
By registering NOOP tasks.

Hi 👋 

I was getting the following exception when running `bundle exec rspec`:

```ruby
rails aborted!
ActiveRecord::Tasks::DatabaseNotSupported: Rake tasks not supported by 'nulldb' adapter
/Users/danilo/workspace/work/foobar/bin/rails:9:in `<top (required)>'
/Users/danilo/workspace/work/foobar/bin/spring:15:in `require'
/Users/danilo/workspace/work/foobar/bin/spring:15:in `<top (required)>'
bin/rails:3:in `load'
bin/rails:3:in `<main>'
Tasks: TOP => db:test:load => db:test:purge
(See full trace by running task with --trace)
```

Tests would still run and succeed but I wanted to address this exception. This is my proposal to prevent this exception from happening.

The way I verified nothing was broken by introducing this change was by running every rake database task (`db:*`):

```bash
bundle exec rake -T | grep -e "^rake db:[^ ]\+" --only-matching | xargs -L 1 bundle exec
```

And checking the output for completion and no exceptions.

Thanks for your hard work on this project 💜 