### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/activerecord-nulldb-adapter.gemspec
+++ b/activerecord-nulldb-adapter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     "README.rdoc"
   ]
   s.files    = `git ls-files`.split($/)
-  s.homepage = "http://github.com/nulldb/nulldb"
+  s.homepage = "https://github.com/nulldb/nulldb"
   s.licenses = ["MIT"]
 
   s.add_runtime_dependency 'activerecord', '>= 2.0.0'


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/activerecord-nulldb-adapter or some tools or APIs that use the gem's metadata.