### PR TITLE
Feature/UUID

### DIFF
--- a/lib/active_record/connection_adapters/nulldb_adapter/table_definition.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/table_definition.rb
@@ -2,7 +2,7 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter
 
   class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
     attr_accessor :name
-    alias_method :uuid, :id
+    alias_method :uuid, :string
     alias_method :citext, :text
     alias_method :interval, :text
     alias_method :geometry, :text

--- a/lib/active_record/connection_adapters/nulldb_adapter/table_definition.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/table_definition.rb
@@ -2,6 +2,7 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter
 
   class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
     attr_accessor :name
+    alias_method :uuid, :id
     alias_method :citext, :text
     alias_method :interval, :text
     alias_method :geometry, :text


### PR DESCRIPTION
Adds uuid alias_method to TableDefinition

This fixes the error when uuids are used as primary keys, which resulted in:
`NameError: undefined method 'uuid' for class ActiveRecord::ConnectionAdapters::NullDBAdapter::TableDefinition`