### PR TITLE
Remove Legacy active record support from codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ doc
 # bundler
 .bundle
 *.lock
+vendor
 
 # gem
 pkg

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'activerecord', '>= 2.0.0'
+gem 'activerecord', '>= 5.2.0', '< 6.1.0'
 
 group :development, :test do
   gem 'spec'

--- a/activerecord-nulldb-adapter.gemspec
+++ b/activerecord-nulldb-adapter.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/nulldb/nulldb"
   s.licenses = ["MIT"]
 
-  s.add_runtime_dependency 'activerecord', '>= 5.2.0'
+  s.add_runtime_dependency 'activerecord', '>= 5.2.0', '< 6.1'
   s.add_development_dependency 'spec'
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'rspec'
@@ -28,4 +28,3 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'simplecov'
 end
-

--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -335,8 +335,7 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
   end
 
   def initialize_args
-    return [nil, @logger, @config] if ActiveRecord::VERSION::MAJOR > 3
-    [nil, @logger]
+    [nil, @logger, @config]
   end
 
   # 4.2 introduced ActiveRecord::Type

--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -34,8 +34,7 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
         self.class.const_get(config[:table_definition_class_name]))
     end
 
-    register_types unless NullDB::LEGACY_ACTIVERECORD || \
-                          ActiveRecord::VERSION::MAJOR < 4
+    register_types
   end
 
   # A log of every statement that has been "executed" by this connection adapter

--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -94,33 +94,6 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
     index = @indexes[table_name].reject! { |index| index.name == index_name }
   end
 
-  unless instance_methods.include? :add_index_options
-    def add_index_options(table_name, column_name, options = {})
-      column_names = Array.wrap(column_name)
-      index_name   = index_name(table_name, :column => column_names)
-
-      index_type = options
-
-      if index_name.length > index_name_length
-        raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' is too long; the limit is #{index_name_length} characters"
-      end
-      if index_name_exists?(table_name, index_name, false)
-        raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' already exists"
-      end
-      index_columns = quoted_columns_for_index(column_names, options).join(", ")
-
-      [index_name, index_type, index_columns]
-    end
-  end
-
-  unless instance_methods.include? :index_name_exists?
-    def index_name_exists?(table_name, index_name, default)
-      return default unless respond_to?(:indexes)
-      index_name = index_name.to_s
-      indexes(table_name).detect { |i| i.name == index_name }
-    end
-  end
-
   def add_fk_constraint(*args)
     # NOOP
   end

--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -364,14 +364,14 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
       [
         col_def.name.to_s,
         col_def.default,
-        col_def.null.nil? || col_def.null # cast  [false, nil, true] => [false, true, true], other adapters default to null=true 
+        col_def.null.nil? || col_def.null # cast  [false, nil, true] => [false, true, true], other adapters default to null=true
       ]
     else
       [
         col_def.name.to_s,
         col_def.default,
         col_def.type,
-        col_def.null.nil? || col_def.null # cast  [false, nil, true] => [false, true, true], other adapters default to null=true 
+        col_def.null.nil? || col_def.null # cast  [false, nil, true] => [false, true, true], other adapters default to null=true
       ]
     end
   end
@@ -390,7 +390,7 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
   def register_types
     if ActiveRecord::VERSION::MAJOR < 5
       type_map.register_type(:primary_key, ActiveRecord::Type::Integer.new)
-    else      
+    else
       require 'active_model/type'
       ActiveRecord::Type.register(
         :primary_key,

--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -329,20 +329,11 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
   end
 
   def default_column_arguments(col_def)
-    if ActiveRecord::VERSION::MAJOR >= 5
-      [
-        col_def.name.to_s,
-        col_def.default,
-        col_def.null.nil? || col_def.null # cast  [false, nil, true] => [false, true, true], other adapters default to null=true
-      ]
-    else
-      [
-        col_def.name.to_s,
-        col_def.default,
-        col_def.type,
-        col_def.null.nil? || col_def.null # cast  [false, nil, true] => [false, true, true], other adapters default to null=true
-      ]
-    end
+    [
+      col_def.name.to_s,
+      col_def.default,
+      col_def.null.nil? || col_def.null # cast  [false, nil, true] => [false, true, true], other adapters default to null=true
+    ]
   end
 
   def initialize_column_with_cast_type?

--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -338,19 +338,13 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
     [nil, @logger, @config]
   end
 
-  # 4.2 introduced ActiveRecord::Type
-  # https://github.com/rails/rails/tree/4-2-stable/activerecord/lib/active_record
   def register_types
-    if ActiveRecord::VERSION::MAJOR < 5
-      type_map.register_type(:primary_key, ActiveRecord::Type::Integer.new)
-    else
-      require 'active_model/type'
-      ActiveRecord::Type.register(
-        :primary_key,
-        ActiveModel::Type::Integer,
-        adapter: adapter_name,
-        override: true
-      )
-    end
+    require 'active_model/type'
+    ActiveRecord::Type.register(
+      :primary_key,
+      ActiveModel::Type::Integer,
+      adapter: adapter_name,
+      override: true
+    )
   end
 end

--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -315,8 +315,6 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
       if defined?(ActiveRecord::ConnectionAdapters::SqlTypeMetadata)
         meta = ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(sql_type: col_def.type)
         args.insert(2, meta_with_limit!(meta, col_def))
-      elsif initialize_column_with_cast_type?
-        args.insert(2, meta_with_limit!(lookup_cast_type(col_def.type), col_def))
       else
         args[2] = args[2].to_s + "(#{col_def.limit})" if col_def.limit
       end
@@ -334,10 +332,6 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
       col_def.default,
       col_def.null.nil? || col_def.null # cast  [false, nil, true] => [false, true, true], other adapters default to null=true
     ]
-  end
-
-  def initialize_column_with_cast_type?
-    ::ActiveRecord::VERSION::MAJOR == 4 && ::ActiveRecord::VERSION::MINOR >= 2
   end
 
   def initialize_args

--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -99,12 +99,7 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
       column_names = Array.wrap(column_name)
       index_name   = index_name(table_name, :column => column_names)
 
-      if Hash === options # legacy support, since this param was a string
-        index_type = options[:unique] ? "UNIQUE" : ""
-        index_name = options[:name].to_s if options.key?(:name)
-      else
-        index_type = options
-      end
+      index_type = options
 
       if index_name.length > index_name_length
         raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' is too long; the limit is #{index_name_length} characters"

--- a/lib/active_record/connection_adapters/nulldb_adapter/core.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/core.rb
@@ -301,10 +301,6 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter < ActiveRecord::Connection
       TableDefinition.new(self, table_name, temporary: is_temporary, options: options.except(:id))
     when 5
       TableDefinition.new(table_name, is_temporary, options.except(:id), nil)
-    when 4
-      TableDefinition.new(native_database_types, table_name, is_temporary, options)
-    when 2,3
-      TableDefinition.new(adapter)
     else
       raise "Unsupported ActiveRecord version #{::ActiveRecord::VERSION::STRING}"
     end

--- a/lib/nulldb/core.rb
+++ b/lib/nulldb/core.rb
@@ -3,9 +3,6 @@ require 'active_support/deprecation'
 require 'active_record/connection_adapters/nulldb_adapter'
 
 module NullDB
-  LEGACY_ACTIVERECORD = 
-    Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('4.2.0')
-
   class Configuration < Struct.new(:project_root); end
 
   class << self

--- a/spec/nulldb_spec.rb
+++ b/spec/nulldb_spec.rb
@@ -11,12 +11,7 @@ require 'active_record'
 require 'active_record/version'
 $: << File.join(File.dirname(__FILE__), "..", "lib")
 
-if ActiveRecord::VERSION::MAJOR > 2
-  require 'rspec' # rspec 2
-else
-  require 'spec' # rspec 1
-end
-
+require 'rspec'
 require 'nulldb_rspec'
 
 class Employee < ActiveRecord::Base
@@ -492,11 +487,9 @@ describe 'adapter-specific extensions' do
     should_have_column(ExtendedModel, :jsonb_column, :json)
   end
 
-  if ActiveRecord::VERSION::MAJOR > 4
-    it 'registers a primary_key type' do
-      expect(ActiveRecord::Type.lookup(:primary_key, adapter: 'NullDB'))
-        .to be_a(ActiveModel::Type::Integer)
-    end
+  it 'registers a primary_key type' do
+    expect(ActiveRecord::Type.lookup(:primary_key, adapter: 'NullDB'))
+      .to be_a(ActiveModel::Type::Integer)
   end
 end
 


### PR DESCRIPTION
### WHY

Project only build against Rails 5.2+ so this removes any legacy code referencing versions before that.

Primary driver for this work was an attempt to move this library to have Rails 6.1 support which will require quite a few changes, reducing the legacy code-paths will help simplify this work.
