### PR TITLE
Fix Rails 6 Deprecations

### DIFF
--- a/spec/nulldb_spec.rb
+++ b/spec/nulldb_spec.rb
@@ -291,7 +291,8 @@ describe "NullDB" do
 end
 
 # need a fallback db for contextual nullification
-ActiveRecord::Base.configurations['test'] = {'adapter' => 'nulldb'}
+db_config = { 'test' => {'adapter' => 'nulldb'} }
+ActiveRecord::Base.configurations = ActiveRecord::DatabaseConfigurations.new(db_config)
 
 describe NullDB::RSpec::NullifiedDatabase do
   describe 'have_executed rspec matcher' do

--- a/spec/nulldb_spec.rb
+++ b/spec/nulldb_spec.rb
@@ -291,8 +291,13 @@ describe "NullDB" do
 end
 
 # need a fallback db for contextual nullification
-db_config = { 'test' => {'adapter' => 'nulldb'} }
-ActiveRecord::Base.configurations = ActiveRecord::DatabaseConfigurations.new(db_config)
+if defined?(ActiveRecord::DatabaseConfigurations)
+  db_config = { 'test' => {'adapter' => 'nulldb'} }
+  ActiveRecord::Base.configurations = ActiveRecord::DatabaseConfigurations.new(db_config)
+else
+  # Support ActiveRecord 5
+  ActiveRecord::Base.configurations['test'] = {'adapter' => 'nulldb'}
+end
 
 describe NullDB::RSpec::NullifiedDatabase do
   describe 'have_executed rspec matcher' do


### PR DESCRIPTION
### WHY

Fixes the deprecation warning:

DEPRECATION WARNING: Setting `ActiveRecord::Base.configurations` with `[]=` is deprecated. Use `ActiveRecord::Base.configurations=` directly to set the configurations instead. (called from <top (required)> at /home/mortlock/src/nulldb/spec/nulldb_spec.rb:299)

Also from Rails 6.1 the ActiveRecord::ConnectionAdapters::SqlTypeMetadata is frozen so you cannot set the limit after construction, reworked this to ensure we do not mutate and simplified the code
