### PR TITLE
Add t.bigserial table modifier alias method

### DIFF
--- a/lib/active_record/connection_adapters/nulldb_adapter/table_definition.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/table_definition.rb
@@ -7,7 +7,6 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter
     alias_method :interval, :text
     alias_method :geometry, :text
     alias_method :serial, :integer
-    alias_method :bigserial, :integer
     alias_method :inet, :string
     alias_method :jsonb, :json if method_defined? :json
   end

--- a/lib/active_record/connection_adapters/nulldb_adapter/table_definition.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/table_definition.rb
@@ -7,6 +7,7 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter
     alias_method :interval, :text
     alias_method :geometry, :text
     alias_method :serial, :integer
+    alias_method :bigserial, :integer
     alias_method :inet, :string
     alias_method :jsonb, :json if method_defined? :json
   end


### PR DESCRIPTION
BigSerial is an autoincrementing integer data type supported by PosgreSQL databases.  