### PR TITLE
Add postgres enum column alias

### DIFF
--- a/lib/active_record/connection_adapters/nulldb_adapter/table_definition.rb
+++ b/lib/active_record/connection_adapters/nulldb_adapter/table_definition.rb
@@ -2,6 +2,7 @@ class ActiveRecord::ConnectionAdapters::NullDBAdapter
 
   class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
     attr_accessor :name
+    alias_method :enum, :string
     alias_method :uuid, :string
     alias_method :citext, :text
     alias_method :interval, :text


### PR DESCRIPTION
Rails 7 introduced enum columns, this PR aliases them to :string