### PR TITLE
Add `check_current_protected_environment!` to `ActiveRecord::Tasks::NullDBDatabaseTasks`

### DIFF
--- a/lib/active_record/tasks/nulldb_database_tasks.rb
+++ b/lib/active_record/tasks/nulldb_database_tasks.rb
@@ -26,4 +26,8 @@ class ActiveRecord::Tasks::NullDBDatabaseTasks
   def clear_active_connections!
     # NO-OP
   end
+
+  def check_current_protected_environment!(db_config, migration_class)
+    # NO-OP
+  end
 end

--- a/spec/nulldb_spec.rb
+++ b/spec/nulldb_spec.rb
@@ -540,3 +540,16 @@ describe ActiveRecord::ConnectionAdapters::NullDBAdapter::EmptyResult do
     expect( result.cast_values ).to be_empty
   end
 end
+
+describe ActiveRecord::Tasks::NullDBDatabaseTasks do
+  it "creates a task with noop methods matching the expected interface" do
+    task = ActiveRecord::Tasks::NullDBDatabaseTasks.new({})
+    expect( task.create ).to be_nil
+    expect( task.drop ).to be_nil
+    expect( task.purge ).to be_nil
+    expect( task.structure_dump("filename", {}) ).to be_nil
+    expect( task.structure_load("filename", {}) ).to be_nil
+    expect( task.clear_active_connections! ).to be_nil
+    expect( task.check_current_protected_environment!({}, Class.new) ).to be_nil
+  end
+end


### PR DESCRIPTION
# Problem

In https://github.com/rails/rails/pull/54879 the `check_current_protected_environment!` was added to the `ActiveRecord::Tasks::AbstractTasks` interface. This was shipped in Rails `8.1.0`.

The `ActiveRecord::Tasks::NullDBDatabaseTasks` class needs to mirror this interface, but does not. Resulting in errors like this when deploying:

```
bin/rails aborted!
NoMethodError: undefined method 'check_current_protected_environment!' for an instance of ActiveRecord::Tasks::NullDBDatabaseTasks (NoMethodError)

          database_adapter_for(db_config).check_current_protected_environment!(db_config, migration_class)
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/app/vendor/bundle/ruby/3.4.0/gems/activerecord-8.1.1/lib/active_record/tasks/database_tasks.rb:69:in 'block in 
```


# Solution

Add the `check_current_protected_environment!` method as a no-op. Test it.

I believe CI would fail now if someone re-ran it, but it doesn't appear to have been run since a Rails 8.1.x release that I can see.